### PR TITLE
SyntaxError: invalid syntax in the def fused_lstm_gates - #6 in python 2.7

### DIFF
--- a/blocksparse/ewops.py
+++ b/blocksparse/ewops.py
@@ -159,9 +159,11 @@ lstm_gates_grad_op  = _op_module.lstm_gates_grad
 lstm_gates4_op      = _op_module.lstm_gates4
 lstm_gates4_grad_op = _op_module.lstm_gates4_grad
 
-def fused_lstm_gates(c, *args, name=None):
+def fused_lstm_gates(c, *args, **kwargs):
     # returns c_next, h_next
-
+    
+    assert len(kwargs) <= 1
+    name = kwargs.pop('name', None)    
     # args is h (all four gates fused in single tensor)
     if len(args) == 1:
         return lstm_gates_op(c, args[0], name=name)


### PR DESCRIPTION
See:  https://stackoverflow.com/questions/15301999/python-2-x-default-arguments-with-args-and-kwargs

Note, it looks like, just replacing the order of *args and name wouldn't work:
>> def lstm_gates2_op(c, a1, a2, name):
>>    print c, a1, a2, name
>>
>> def fused_lstm_gates(c, name=None, *args):
>>    print len(args)
>>    assert len(args) == 2
>>    return lstm_gates2_op(c, *args, name=name)

>> fused_lstm_gates(1, 2, 3, 4)
2
1 3 4 2
>> fused_lstm_gates(1, 2, 3, name=4)
TypeError: fused_lstm_gates() got multiple values for keyword argument 'name'

While the following is:
>> def lstm_gates2_op(c, a1, a2, name):
>>     print c, a1, a2, name
>> 
>>  def fused_lstm_gates(c, *args, **kwargs):
>>     name = kwargs.pop('name', None)
>>     assert len(args) == 2
>>     return lstm_gates2_op(c, *args, name=name)
>> 
>>  fused_lstm_gates(1, 2, 3)
1 2 3 None
>>  fused_lstm_gates(1, 2, 3, "test")
1 2 3 test