### PR TITLE
np.fromfile instead of np.fromstring is shorter and doesn't throw assertion in python 2.7.

### DIFF
--- a/examples/lstm/utils.py
+++ b/examples/lstm/utils.py
@@ -39,8 +39,7 @@ def text8_stream(text, nbatch, nsteps, maxbatches=None):
 
 
 def text_to_npy(path, nbytes=-1):
-    text = open(path).read(nbytes).encode()
-    text = np.fromstring(text, dtype=np.uint8)
+    text = np.fromfile(path, dtype=np.uint8, count=nbytes)
     return text
 
 def wiki3(path):


### PR DESCRIPTION
Original code, in python 2.7 was resulting in:

python train.py 
('opening:', '/home/dchichkov/n/wikitext-103-raw')
Traceback (most recent call last):
  File "train.py", line 183, in <module>
    trX, vaX, teX = wiki3(path=args.data_file)
  File "/home/dchichkov/n/blocksparse/examples/lstm/utils.py", line 48, in wiki3
    tr_text = text_to_npy(os.path.join(path, "wiki.train.raw"))
  File "/home/dchichkov/n/blocksparse/examples/lstm/utils.py", line 42, in text_to_npy
    text = open(path).read(nbytes).encode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 39: ordinal not in range(128)